### PR TITLE
feat: add pagination system to product list

### DIFF
--- a/src/app/(root)/components/beauty-section.tsx
+++ b/src/app/(root)/components/beauty-section.tsx
@@ -3,8 +3,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { trpc } from "@/trpc/server";
 
 export const BeautySection = async () => {
-  const beauty = await trpc.product.getAll({subCategory: "Beauty"})
-  
+  const { products } = await trpc.product.getAll({ subCategory: "Beauty" });
+
   return (
     <section className="mt-20">
       <div className="flex flex-col w-full md:w-96 mx-auto mb-5">
@@ -16,12 +16,8 @@ export const BeautySection = async () => {
       </div>
       <hr className="mb-5 h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-neutral-900 to-transparent opacity-25 dark:via-white" />
       <div className="flex gap-1 md:gap-5 overflow-scroll no-scrollbar px-1 py-px snap-x snap-mandatory">
-        {beauty.map((product) => (
-          <ProductCard
-            key={product.slug}
-            {...product}
-            className="product-card-container"
-          />
+        {products.map((product) => (
+          <ProductCard key={product.slug} {...product} className="product-card-container" />
         ))}
       </div>
     </section>
@@ -29,7 +25,7 @@ export const BeautySection = async () => {
 };
 
 export const BeautySectionFallback = () => {
-  return(
+  return (
     <section className="mt-20">
       <div className="flex flex-col w-full md:w-96 mx-auto mb-5">
         <h2 className="text-2xl lg:text-4xl font-bold text-center">GabaG Beauty</h2>
@@ -41,9 +37,9 @@ export const BeautySectionFallback = () => {
       <hr className="mb-5 h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-neutral-900 to-transparent opacity-25 dark:via-white" />
       <div className="flex gap-1 md:gap-5 overflow-scroll no-scrollbar px-1 py-px snap-x snap-mandatory">
         {[...Array(6)].map((_, index) => (
-          <Skeleton key={index} className="min-w-60 md:min-w-sm aspect-[1/1.8]"/>
+          <Skeleton key={index} className="min-w-60 md:min-w-sm aspect-[1/1.8]" />
         ))}
       </div>
     </section>
-  )
-}
+  );
+};

--- a/src/app/(root)/components/breastpump-section.tsx
+++ b/src/app/(root)/components/breastpump-section.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { trpc } from "@/trpc/server";
 
 export const BreastPumpSection = async () => {
-  const products = await trpc.product.getAll({ subCategory: "Breast Pump" });
+  const { products } = await trpc.product.getAll({ subCategory: "Breast Pump" });
   return (
     <section>
       <div className="flex flex-col w-full md:w-[460px] mx-auto mb-5 mt-10 gap-2">

--- a/src/app/(root)/products/[slug]/page.tsx
+++ b/src/app/(root)/products/[slug]/page.tsx
@@ -35,8 +35,8 @@ export async function generateMetadata({ params }: {params: tParams}): Promise<M
 const ProductDetailsPage = async ({ params }: {params: tParams}) => {
   const { slug }: {slug: string} = await params;
   const product = await trpc.product.getBySlug({slug});
-  const products = await trpc.product.getAll({subCategory: product.subCategory.name})
-  
+  const result = await trpc.product.getAll({subCategory: product.subCategory.name})
+
   if (!product) {
     return <div>Product not found</div>;
   }
@@ -45,11 +45,11 @@ const ProductDetailsPage = async ({ params }: {params: tParams}) => {
     <div className="flex flex-col px-5 w-full max-w-screen mt-10">
       <ProductDetailSection product={product} />
 
-      {products && (
+      {result.products && result.products.length > 0 && (
         <div className="mt-10">
           <p className="text-lg lg:text-2xl">You Might Also Like</p>
           <div className="flex gap-1 mt-5 md:gap-5 overflow-scroll no-scrollbar snap-x snap-mandatory py-px">
-            {products.map((product) => (
+            {result.products.map((product) => (
               <ProductCard
                 {...product}
                 key={product.slug}

--- a/src/app/(root)/products/components/product-list.tsx
+++ b/src/app/(root)/products/components/product-list.tsx
@@ -1,6 +1,8 @@
 import ProductCard from "@/components/shared/product-card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PRODUCT_LIST_LIMIT } from "@/lib/constants";
 import { trpc } from "@/trpc/server";
+import ProductPagination from "./product-pagination";
 
 interface ProductListProps {
   search?: string;
@@ -8,41 +10,47 @@ interface ProductListProps {
   sort?: string;
   max?: string;
   min?: string;
+  page?: string;
 }
 
-const ProductList = async ({ search, max, min, subCategoryIds: subCategoriesId }: ProductListProps) => {
-  const products = await trpc.product.getAll({
+const ProductList = async ({
+  search,
+  max,
+  min,
+  subCategoryIds: subCategoriesId,
+  page,
+}: ProductListProps) => {
+  const result = await trpc.product.getAll({
     search,
     subCategoriesId,
     price: {
       max,
       min,
     },
+    limit: PRODUCT_LIST_LIMIT,
+    page: Number(page) || 1,
   });
 
+  const { products, currentPage, totalPages } = result;
+
   return (
-    <div
-      className={`
-        grid 
-        w-full 
-        gap-2 
-        md:gap-5 
-        grid-cols-2 
-        lg:grid-cols-3
-        xl:grid-cols-4
-        h-full
-      `}
-    >
-      {products && products?.length !== 0 ? (
-        products.map((product) => (
-          <ProductCard key={product.slug} className="col-span-1" {...product} />
-        ))
-      ) : (
-        <p className="text-lg text-neutral-500 text-center mt-36 col-span-4">
-          There is no products.
-        </p>
-      )}
-    </div>
+    <>
+      <div className="grid w-full gap-2 md:gap-5 grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 h-full">
+        {products && products.length !== 0 ? (
+          products.map((product) => (
+            <ProductCard key={product.slug} className="col-span-1" {...product} />
+          ))
+        ) : (
+          <p className="text-lg text-neutral-500 text-center mt-36 col-span-4">
+            There is no products.
+          </p>
+        )}
+      </div>
+      <ProductPagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+      />
+    </>
   );
 };
 

--- a/src/app/(root)/products/components/product-pagination.tsx
+++ b/src/app/(root)/products/components/product-pagination.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination"
+import { useSearchParams, usePathname } from "next/navigation";
+
+interface ProductPaginationProps {
+  currentPage: number;
+  totalPages: number;
+}
+
+export default function ProductPagination({ currentPage, totalPages }: ProductPaginationProps) {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  const createPageURL = (page: number) => {
+    const params = new URLSearchParams(searchParams);
+    params.set('page', page.toString());
+    return `${pathname}?${params.toString()}`;
+  };
+
+  // Generate page numbers to display
+  const getPageNumbers = () => {
+    const pages: (number | 'ellipsis')[] = [];
+    const showEllipsis = totalPages > 7;
+
+    if (!showEllipsis) {
+      // Show all pages if total is 7 or less
+      for (let i = 1; i <= totalPages; i++) {
+        pages.push(i);
+      }
+    } else {
+      // Always show first page
+      pages.push(1);
+
+      if (currentPage > 3) {
+        pages.push('ellipsis');
+      }
+
+      // Show pages around current page
+      const start = Math.max(2, currentPage - 1);
+      const end = Math.min(totalPages - 1, currentPage + 1);
+
+      for (let i = start; i <= end; i++) {
+        pages.push(i);
+      }
+
+      if (currentPage < totalPages - 2) {
+        pages.push('ellipsis');
+      }
+
+      // Always show last page
+      pages.push(totalPages);
+    }
+
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-center items-center mt-10">
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href={currentPage > 1 ? createPageURL(currentPage - 1) : '#'}
+              aria-disabled={currentPage === 1}
+              className={currentPage === 1 ? 'pointer-events-none opacity-50' : ''}
+            />
+          </PaginationItem>
+
+          {pageNumbers.map((page, index) => (
+            page === 'ellipsis' ? (
+              <PaginationItem key={`ellipsis-${index}`}>
+                <PaginationEllipsis />
+              </PaginationItem>
+            ) : (
+              <PaginationItem key={page}>
+                <PaginationLink
+                  href={createPageURL(page)}
+                  isActive={currentPage === page}
+                >
+                  {page}
+                </PaginationLink>
+              </PaginationItem>
+            )
+          ))}
+
+          <PaginationItem>
+            <PaginationNext
+              href={currentPage < totalPages ? createPageURL(currentPage + 1) : '#'}
+              aria-disabled={currentPage === totalPages}
+              className={currentPage === totalPages ? 'pointer-events-none opacity-50' : ''}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+    </div>
+  );
+}

--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -19,15 +19,16 @@ const ProductPage = async ({searchParams}: {
     min: string;
     max: string;
     category: string;
+    page: string;
   }>
 }) => {
-  const {subCategories, search, max, min, sort, category} = await searchParams
+  const {subCategories, search, max, min, sort, category, page} = await searchParams
   const subCategoryIds = subCategories?.split(',').filter(Boolean)
 
   const categories = await trpc.category.getById({id: category})
-  
+
   const subCategoryList = await trpc.subCategory.getSelect(category)
-  
+
   return (
     <div className="mx-3 xl:mx-10 flex flex-col items-center">
 
@@ -68,9 +69,9 @@ const ProductPage = async ({searchParams}: {
               max={max}
               min={min}
               sort={sort}
+              page={page}
             />
           </Suspense>
-
         </div>
       </div>
     </div>

--- a/src/app/admin/catalog/product/columns.tsx
+++ b/src/app/admin/catalog/product/columns.tsx
@@ -7,7 +7,7 @@ import Image from "next/image";
 import { RouterOutputs } from "@/trpc/routers/_app";
 import { useDeleteMutation } from "@/hooks/use-delete-mutation";
 
-export type Product = RouterOutputs['product']['getAll'][number]
+export type Product = RouterOutputs['product']['getAll']['products'][number]
 
 const ProductActionCell = ({ productId }: { productId: string }) => {
   const deleteProductMutation = useDeleteMutation({ type: "product" });

--- a/src/app/admin/catalog/product/components/product-data-table-wrapper.tsx
+++ b/src/app/admin/catalog/product/components/product-data-table-wrapper.tsx
@@ -5,7 +5,7 @@ import { columns } from "../columns";
 import { useDeleteManyMutation } from "@/hooks/use-delete-mutation";
 import { RouterOutputs } from "@/trpc/routers/_app";
 
-type Product = RouterOutputs['product']['getAll'][number];
+type Product = RouterOutputs['product']['getAll']['products'][number];
 
 interface ProductDataTableWrapperProps {
   products: Product[];

--- a/src/app/admin/catalog/product/page.tsx
+++ b/src/app/admin/catalog/product/page.tsx
@@ -4,8 +4,8 @@ import { trpc } from "@/trpc/server";
 import ProductDataTableWrapper from "./components/product-data-table-wrapper";
 
 export default async function AdminProductPage() {
-  const products = await trpc.product.getAll({});
-  
+  const { products } = await trpc.product.getAll({});
+
   return (
     <div className="form-page">
       <div className="flex justify-between items-center">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -125,6 +125,8 @@ export const DEFAULT_EMAIL = "placeholder@mail.com";
 export const DEFAULT_NAME = "NO_NAME";
 export const DEFAULT_PHONE = "0888888888";
 
+export const PRODUCT_LIST_LIMIT = 24
+
 // Order form field requirements
 export const REQUIRED_ORDER_FIELDS = [
   "address",


### PR DESCRIPTION
- Implement server-side pagination in product.getAll tRPC router
  - Add page parameter with default value of 1
  - Return object with products array, totalCount, currentPage, and totalPages
  - Add skip/take logic for efficient data fetching
- Create ProductPagination component with smart page number display
  - Dynamic ellipsis rendering for large page counts (>7 pages)
  - URL-based navigation preserving all query parameters
  - Disabled states for prev/next buttons at boundaries
- Update all components using product.getAll to destructure new response
  - Refactor beauty-section, breastpump-section, and admin product page
  - Update product detail page "You Might Also Like" section
  - Fix RouterOutputs types to access products array correctly
- Add PRODUCT_LIST_LIMIT constant (24 items per page)
- Enhance ProductList component to handle pagination data

🤖 Generated with [Claude Code](https://claude.com/claude-code)