### PR TITLE
fix slow category switching by adding key props to suspense boundaries

### DIFF
--- a/src/app/(root)/products/page.tsx
+++ b/src/app/(root)/products/page.tsx
@@ -28,12 +28,12 @@ const ProductPage = async ({
 
   return (
     <div className="mx-3 xl:mx-10 flex flex-col items-center">
-      <Suspense fallback={<CategoryBannerFallback />}>
+      <Suspense key={`banner-${category}`} fallback={<CategoryBannerFallback />}>
         <CategoryBanner categoryId={category} />
       </Suspense>
 
       <div className="flex items-start w-full relative flex-col md:flex-row justify-between lg:gap-5 min-h-[500px]">
-        <Suspense fallback={<FilterWrapperFallback />}>
+        <Suspense key={`filter-${category}`} fallback={<FilterWrapperFallback />}>
           <FilterWrapper
             categoryId={category}
             initialSelectedSubCategories={subCategoryIds}
@@ -47,7 +47,7 @@ const ProductPage = async ({
             </p>
           )}
 
-          <Suspense fallback={<ProductListFallback />}>
+          <Suspense key={`products-${category}-${subCategoryIds?.join(',') || 'all'}-${search || ''}-${page || '1'}`} fallback={<ProductListFallback />}>
             <ProductList
               subCategoryIds={subCategoryIds}
               categoryId={category}


### PR DESCRIPTION
Previously when navigating between categories (e.g., mom → beauty → kids), the page felt slow because React didn't re-mount components when only query params changed. This caused Suspense boundaries to not re-trigger, showing stale data while fetching new data in the background without loading states.

Solution:
- add unique key props to all Suspense boundaries based on query params
- banner suspense key includes category
- filter suspense key includes category
- products suspense key includes category, subcategories, search, and page
- forces React to unmount/remount components when keys change
- ensures loading skeletons display during category transitions